### PR TITLE
[REFACTOR] 회원 탈퇴 로직 변경

### DIFF
--- a/src/main/java/com/umc/intercom/controller/WithdrawController.java
+++ b/src/main/java/com/umc/intercom/controller/WithdrawController.java
@@ -7,10 +7,7 @@ import com.umc.intercom.service.WithdrawService;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -22,11 +19,19 @@ public class WithdrawController {
         this.withdrawService = withdrawService;
     }
 
-    @Operation(summary = "회원 탈퇴", description = "올바른 비밀번호를 입력해야 탈퇴 가능")
+    @Operation(summary = "회원 탈퇴", description = "최종 탈퇴")
     @DeleteMapping("/withdraw")
-    public ResponseEntity<Void> withdraw(@RequestBody String password) {
+    public ResponseEntity<Void> withdraw() {
         String userEmail = SecurityUtil.getCurrentUsername();
-        withdrawService.withdraw(userEmail, password);
+        withdrawService.withdraw(userEmail);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "회원 탈퇴 전 본인 인증", description = "올바른 비밀번호를 입력해야 탈퇴 가능")
+    @PostMapping("/withdraw/validate")
+    public ResponseEntity<Void> validateBeforeWithdraw(@RequestBody UserDto.ValidateRequestDto requestDto) {
+        String userEmail = SecurityUtil.getCurrentUsername();
+        withdrawService.validateBeforeWithdraw(userEmail, requestDto.getPassword());
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/umc/intercom/dto/UserDto.java
+++ b/src/main/java/com/umc/intercom/dto/UserDto.java
@@ -21,6 +21,11 @@ public class UserDto {
     }
 
     @Getter
+    public static class ValidateRequestDto {
+        String password;
+    }
+
+    @Getter
     @Setter
     public static class SignUpRequestDto{
         String email;

--- a/src/main/java/com/umc/intercom/service/WithdrawService.java
+++ b/src/main/java/com/umc/intercom/service/WithdrawService.java
@@ -22,15 +22,21 @@ public class WithdrawService {
         this.passwordEncoder = passwordEncoder;
     }
 
-    public void withdraw(String userEmail, String password) {
+    public void withdraw(String userEmail) {
+        User user = userRepository.findByEmail(userEmail)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
+
+        userRepository.delete(user);
+    }
+
+    public void validateBeforeWithdraw(String userEmail, String password) {
         User user = userRepository.findByEmail(userEmail)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));
 
         if(!passwordEncoder.matches(password, user.getPassword())) {
             throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
         }
-
-        userRepository.delete(user);
     }
+
 }
 


### PR DESCRIPTION
- 기존: 회원 탈퇴 시 비밀번호 확인 후 탈퇴 진행(api 1개)
- 변경: 본인 인증과 탈퇴 따로 진행(api 2개)