### PR TITLE
[ADD] 답변 채택 로직 변경

### DIFF
--- a/src/main/java/com/umc/intercom/controller/CommentController.java
+++ b/src/main/java/com/umc/intercom/controller/CommentController.java
@@ -48,13 +48,6 @@ public class CommentController {
         return commentService.createReplyComment(userEmail, replyRequestDto);
     }
 
-    @Operation(summary = "답변 채택 여부 확인", description = "{talkId} 자리에 톡톡 게시글 id를 전달해주세요.\n\n채택된 댓글이 존재하면 true, 존재하지 않으면 false를 반환")
-    @GetMapping("/adoption-status/{talkId}")
-    public ResponseEntity<Boolean> checkAdoptionStatusInTalk(@PathVariable Long talkId) {
-        boolean isAdopted = commentService.checkAdoptionStatus(talkId);
-        return ResponseEntity.ok(isAdopted);
-    }
-
     @Operation(summary = "답변 채택", description = "{id} 자리에 채택할 댓글 id를 전달해주세요.")
     @PostMapping("/{id}/adopt")
     public ResponseEntity<CommentDto.CommentResponseDto> adoptComment(@PathVariable Long id) {

--- a/src/main/java/com/umc/intercom/service/CommentService.java
+++ b/src/main/java/com/umc/intercom/service/CommentService.java
@@ -134,6 +134,11 @@ public class CommentService {
             throw new IllegalStateException("이미 채택된 답변입니다.");
         }
 
+        Long talkId = comment.getTalk().getId();
+        if (checkAdoptionStatus(talkId)) {
+            throw new IllegalStateException("답변 채택은 게시글 당 하나만 가능합니다.");
+        }
+
         comment.setAdoptionStatus(AdoptionStatus.ADOPTED);
         Comment savedComment = commentRepository.save(comment);
         return CommentDto.CommentResponseDto.toDto(savedComment);


### PR DESCRIPTION
- 기존: 톡톡에 채택된 댓글 존재하는지 검증하는 api 따로 구현
- 변경: 답변 채택 api 호출 시 서비스 코드에서 검증하도록 변경